### PR TITLE
debug: remove pytest-lazy-fixture

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -613,20 +613,6 @@ pluggy = ">=1.5,<2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
-name = "pytest-lazy-fixture"
-version = "0.6.3"
-description = "It helps to use fixtures in pytest.mark.parametrize"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytest-lazy-fixture-0.6.3.tar.gz", hash = "sha256:0e7d0c7f74ba33e6e80905e9bfd81f9d15ef9a790de97993e34213deb5ad10ac"},
-    {file = "pytest_lazy_fixture-0.6.3-py3-none-any.whl", hash = "sha256:e0b379f38299ff27a653f03eaa69b08a6fd4484e46fd1c9907d984b9f9daeda6"},
-]
-
-[package.dependencies]
-pytest = ">=3.2.5"
-
-[[package]]
 name = "pyyaml"
 version = "6.0.2"
 description = "YAML parser and emitter for Python"
@@ -791,4 +777,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "230e4255c7e0a628ef4eed1b4b9553fd45dc62e4e0af2726c6c2a0a34901222e"
+content-hash = "1ebc60ccf490ef69da231b7ccf7d2987458f9e314b95c8bd63e76535888ee78b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ numpydantic = "^1.6.3"
 opencv-python = "^4.10.0.84"
 tqdm = "^4.66.5"
 rich = "^13.9.1"
-pytest-lazy-fixture = "^0.6.3"
 
 
 [build-system]


### PR DESCRIPTION
this fixes the E   AttributeError: 'CallSpec2' object has no attribute 'funcargs' error from test_log.py