### PR TITLE
112 validation layer for essential array types

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,3 @@
-## 📝 Description
-
-
 ## 🔍 Type of Change
 
 <!--
@@ -13,7 +10,8 @@ Please delete options that are not relevant.
 🧹 **Refactor:** Code changes that neither fix a bug nor add a feature
 🗑️ **Chore:** Maintenance tasks, such as dependency updates
 
-## 🚀 Implementation Details
+
+## 📝 Description
 
 
 ## 🧪 Testing

--- a/src/cala/models/access.py
+++ b/src/cala/models/access.py
@@ -1,8 +1,5 @@
 import xarray as xr
-from xarray_validate import CoordsSchema, DataArraySchema, DimsSchema, DTypeSchema
-
-from cala.models.axis import Coord
-from cala.models.entity import Entity
+from xarray_validate import DataArraySchema
 
 
 @xr.register_dataarray_accessor("validate")
@@ -10,33 +7,12 @@ class DaValidator:
     def __init__(self, xarray_obj: xr.DataArray):
         self._obj = xarray_obj
 
-    def _build_coord_schema(self, coords: list[Coord]) -> CoordsSchema:
-        return CoordsSchema(
-            {
-                c.name: DataArraySchema(dims=DimsSchema((c.dim,)), dtype=DTypeSchema(c.dtype))
-                for c in coords
-            }
-        )
-
-    def _build_entity_schema(self, schema: Entity) -> DataArraySchema:
-        coords_schema = self._build_coord_schema(schema.coords) if schema.coords else None
-
-        return DataArraySchema(
-            dims=DimsSchema(tuple(dim.name for dim in schema.dims), ordered=False),
-            coords=coords_schema,
-            dtype=DTypeSchema(schema.dtype),
-        )
-
-    def against_schema(self, schema: Entity) -> bool:
+    def against_schema(self, schema: DataArraySchema) -> bool:
         """
-        Validates the DataArray against a given Pydantic schema.
+        Validates the DataArray against a given xarray-schema model.
         Raises ValueError if validation fails.
         """
-        da_schema = self._build_entity_schema(schema)
 
-        da_schema.validate(self._obj)
-
-        # check coordinate data rules
-        # check actual value rules
+        schema.validate(self._obj)
 
         return True

--- a/src/cala/models/axis.py
+++ b/src/cala/models/axis.py
@@ -1,6 +1,8 @@
 from enum import Enum
+from typing import Callable
 
 from pydantic import BaseModel, Field
+from cala.models.checks import is_unique, is_unit_interval
 
 
 class Axis:
@@ -38,6 +40,7 @@ class Coord(BaseModel):
     name: str
     dtype: type
     dim: str | None = None
+    checks: list[Callable] = Field(default_factory=list)
 
 
 class Dim(BaseModel):
@@ -46,12 +49,12 @@ class Dim(BaseModel):
 
 
 class Coords(Enum):
-    id = Coord(name=AXIS.id_coord, dtype=str)
-    height = Coord(name=AXIS.height_coord, dtype=int)
-    width = Coord(name=AXIS.width_coord, dtype=int)
-    frame = Coord(name=AXIS.frame_coord, dtype=int)
+    id = Coord(name=AXIS.id_coord, dtype=str, checks=[is_unique])
+    height = Coord(name=AXIS.height_coord, dtype=int, checks=[is_unique])
+    width = Coord(name=AXIS.width_coord, dtype=int, checks=[is_unique])
+    frame = Coord(name=AXIS.frame_coord, dtype=int, checks=[is_unique])
     timestamp = Coord(name=AXIS.timestamp_coord, dtype=str)
-    confidence = Coord(name=AXIS.confidence_coord, dtype=float)
+    confidence = Coord(name=AXIS.confidence_coord, dtype=float, checks=[is_unit_interval])
 
 
 class Dims(Enum):

--- a/src/cala/models/axis.py
+++ b/src/cala/models/axis.py
@@ -1,7 +1,8 @@
+from collections.abc import Callable
 from enum import Enum
-from typing import Callable
 
 from pydantic import BaseModel, Field
+
 from cala.models.checks import is_unique, is_unit_interval
 
 

--- a/src/cala/models/checks.py
+++ b/src/cala/models/checks.py
@@ -1,5 +1,5 @@
-import xarray as xr
 import numpy as np
+import xarray as xr
 
 
 def is_non_negative(da: xr.DataArray) -> None:

--- a/src/cala/models/checks.py
+++ b/src/cala/models/checks.py
@@ -1,0 +1,18 @@
+import xarray as xr
+import numpy as np
+
+
+def is_non_negative(da: xr.DataArray) -> None:
+    if da.min() < 0:
+        raise ValueError("Array is not non-negative")
+
+
+def is_unique(da: xr.DataArray) -> None:
+    _, counts = np.unique(da, return_counts=True)
+    if counts.max() > 1:
+        raise ValueError("The values in DataArray are not unique.")
+
+
+def is_unit_interval(da: xr.DataArray) -> None:
+    if da.min() < 0 or da.max() > 1:
+        raise ValueError("The values in DataArray are not unit interval.")

--- a/src/cala/models/entity.py
+++ b/src/cala/models/entity.py
@@ -36,14 +36,6 @@ class Entity(BaseModel):
             self.coords.extend(dim.coords)
 
 
-class Entities(Enum):
-    footprint = Entity(name="footprint", dims=(Dims.width.value, Dims.height.value), dtype=float)
-    trace = Entity(name="trace", dims=(Dims.frame.value,), dtype=float)
-    frame = Entity(
-        name="frame", dims=(Dims.width.value, Dims.height.value, Dims.frame.value), dtype=float
-    )
-
-
 class Group(Entity):
     """
     an xarray dataarray entity that is also a group of entities.
@@ -59,11 +51,3 @@ class Group(Entity):
             self.dims = self.entity.dims + (self.group_by.value,)
             self.coords = self.entity.coords + self.group_by.value.coords
         self.dtype = self.entity.dtype
-
-
-class Groups(Enum):
-    footprint = Group(
-        name="footprint-group", entity=Entities.footprint.value, group_by=Dims.component
-    )
-    trace = Group(name="trace-group", entity=Entities.trace.value, group_by=Dims.component)
-    movie = Group(name="movie", entity=Entities.frame.value)

--- a/src/cala/models/entity.py
+++ b/src/cala/models/entity.py
@@ -1,8 +1,9 @@
+from collections.abc import Callable
 from enum import Enum
-from typing import Any, Callable
+from typing import Any
 
 from pydantic import BaseModel, Field, PrivateAttr
-from xarray_validate import DataArraySchema, DimsSchema, DTypeSchema, CoordsSchema
+from xarray_validate import CoordsSchema, DataArraySchema, DimsSchema, DTypeSchema
 
 from cala.models.axis import Coord, Dim, Dims
 

--- a/src/cala/models/entity.py
+++ b/src/cala/models/entity.py
@@ -78,9 +78,13 @@ class Group(Entity):
     dtype: type = Field(default=Any)
 
     def model_post_init(self, __context__: None = None) -> None:
+        self.dims = self.entity.dims
+        self.coords = self.entity.coords
+
         if self.group_by:
-            self.dims = self.entity.dims + (self.group_by.value,)
-            self.coords = self.entity.coords + self.group_by.value.coords
+            self.dims += (self.group_by.value,)
+            self.coords += self.group_by.value.coords
+
         self.dtype = self.entity.dtype
         self.checks = list(set(self.checks + self.entity.checks))
 

--- a/src/cala/models/observable.py
+++ b/src/cala/models/observable.py
@@ -2,89 +2,93 @@ from typing import ClassVar
 
 import xarray as xr
 from pydantic import BaseModel, PrivateAttr, field_validator
-from xarray_validate import CoordsSchema, DataArraySchema, DimsSchema, DTypeSchema
 
-from cala.models.axis import Coord, Dims
+from cala.models.axis import Dims
+from cala.models.checks import is_non_negative
 from cala.models.entity import Entity, Group
 
 
 class Observable(BaseModel):
     array: xr.DataArray
-    _model: ClassVar[Entity]
+    _entity: ClassVar[Entity]
 
     class Config:
         arbitrary_types_allowed = True
         validate_assignment = True
 
     @classmethod
-    def model(cls) -> Entity:
-        return cls._model
+    def entity(cls) -> Entity:
+        return cls._entity
 
     @field_validator("array", mode="after")
     @classmethod
     def validate_array_schema(cls, value: xr.DataArray) -> xr.DataArray:
-        schema = cls._build_entity_schema(cls._model)
-        value.validate.against_schema(schema)
+        value.validate.against_schema(cls._entity.model)
 
         return value
-
-    @staticmethod
-    def _build_coord_schema(coords: list[Coord]) -> CoordsSchema:
-        return CoordsSchema(
-            {
-                c.name: DataArraySchema(dims=DimsSchema((c.dim,)), dtype=DTypeSchema(c.dtype))
-                for c in coords
-            }
-        )
-
-    @classmethod
-    def _build_entity_schema(cls, schema: Entity) -> DataArraySchema:
-        coords_schema = cls._build_coord_schema(schema.coords) if schema.coords else None
-
-        return DataArraySchema(
-            dims=DimsSchema(tuple(dim.name for dim in schema.dims), ordered=False),
-            coords=coords_schema,
-            dtype=DTypeSchema(schema.dtype),
-        )
 
 
 class Footprint(Observable):
     array: xr.DataArray
-    _model: ClassVar[Entity] = PrivateAttr(
-        Entity(name="footprint", dims=(Dims.width.value, Dims.height.value), dtype=float)
+    _entity: ClassVar[Entity] = PrivateAttr(
+        Entity(
+            name="footprint",
+            dims=(Dims.width.value, Dims.height.value),
+            dtype=float,
+            checks=[is_non_negative],
+        )
     )
 
 
 class Trace(Observable):
     array: xr.DataArray
-    _model: ClassVar[Entity] = PrivateAttr(
-        Entity(name="trace", dims=(Dims.frame.value,), dtype=float)
+    _entity: ClassVar[Entity] = PrivateAttr(
+        Entity(name="trace", dims=(Dims.frame.value,), dtype=float, checks=[is_non_negative])
     )
 
 
 class Frame(Observable):
     array: xr.DataArray
-    _model: ClassVar[Entity] = PrivateAttr(
+    _entity: ClassVar[Entity] = PrivateAttr(
         Entity(
-            name="frame", dims=(Dims.width.value, Dims.height.value, Dims.frame.value), dtype=float
+            name="frame",
+            dims=(Dims.width.value, Dims.height.value, Dims.frame.value),
+            dtype=float,
+            checks=[is_non_negative],
         )
     )
 
 
 class Footprints(Observable):
     array: xr.DataArray
-    _model: ClassVar[Entity] = PrivateAttr(
-        Group(name="footprint-group", entity=Footprint.model(), group_by=Dims.component)
+    _entity: ClassVar[Entity] = PrivateAttr(
+        Group(
+            name="footprint-group",
+            entity=Footprint.entity(),
+            group_by=Dims.component,
+            checks=[is_non_negative],
+        )
     )
 
 
 class Traces(Observable):
     array: xr.DataArray
-    _model: ClassVar[Entity] = PrivateAttr(
-        Group(name="trace-group", entity=Trace.model(), group_by=Dims.component)
+    _entity: ClassVar[Entity] = PrivateAttr(
+        Group(
+            name="trace-group",
+            entity=Trace.entity(),
+            group_by=Dims.component,
+            checks=[is_non_negative],
+        )
     )
 
 
 class Movie(Observable):
     array: xr.DataArray
-    _model: ClassVar[Entity] = PrivateAttr(Group(name="movie", entity=Frame.model()))
+    _entity: ClassVar[Entity] = PrivateAttr(
+        Group(
+            name="movie",
+            entity=Frame.entity(),
+            checks=[is_non_negative],
+        )
+    )

--- a/src/cala/models/observable.py
+++ b/src/cala/models/observable.py
@@ -1,0 +1,67 @@
+from typing import Annotated, get_args
+
+import xarray as xr
+from pydantic import BaseModel, field_validator
+
+from cala.models.axis import Dims
+from cala.models.entity import Entity, Group
+
+
+class Observable(BaseModel):
+    array: Annotated[xr.DataArray, Entity]
+
+    class Config:
+        arbitrary_types_allowed = True
+        validate_assignment = True
+
+    @field_validator("array", mode="after")
+    @classmethod
+    def validate_array_schema(cls, value: xr.DataArray) -> None:
+        value.validate.against_schema(get_args(cls.array)[1])
+
+
+TFootprint: type = Annotated[
+    xr.DataArray, Entity(name="footprint", dims=(Dims.width.value, Dims.height.value), dtype=float)
+]
+
+TTrace: type = Annotated[xr.DataArray, Entity(name="trace", dims=(Dims.frame.value,), dtype=float)]
+
+TFrame: type = Annotated[
+    xr.DataArray,
+    Entity(name="frame", dims=(Dims.width.value, Dims.height.value, Dims.frame.value), dtype=float),
+]
+
+TFootprints: type = Annotated[
+    xr.DataArray,
+    Group(name="footprint-group", entity=get_args(TFootprint)[1], group_by=Dims.component),
+]
+
+TTraces: type = Annotated[
+    xr.DataArray, Group(name="trace-group", entity=get_args(TTrace)[1], group_by=Dims.component)
+]
+
+TMovie: type = Annotated[xr.DataArray, Group(name="movie", entity=get_args(TFrame)[1])]
+
+
+class Footprint(Observable):
+    array: TFootprint
+
+
+class Trace(Observable):
+    array: TTrace
+
+
+class Frame(Observable):
+    array: TFrame
+
+
+class Footprints(Observable):
+    array: TFootprints
+
+
+class Traces(Observable):
+    array: TTraces
+
+
+class Movie(Observable):
+    array: TMovie

--- a/src/cala/models/observable.py
+++ b/src/cala/models/observable.py
@@ -22,9 +22,11 @@ class Observable(BaseModel):
 
     @field_validator("array", mode="after")
     @classmethod
-    def validate_array_schema(cls, value: xr.DataArray) -> None:
+    def validate_array_schema(cls, value: xr.DataArray) -> xr.DataArray:
         schema = cls._build_entity_schema(cls._model)
         value.validate.against_schema(schema)
+
+        return value
 
     @staticmethod
     def _build_coord_schema(coords: list[Coord]) -> CoordsSchema:

--- a/src/cala/streaming/nodes/init/cold/catalog.py
+++ b/src/cala/streaming/nodes/init/cold/catalog.py
@@ -1,4 +1,3 @@
-from collections.abc import Hashable, Mapping
 from dataclasses import dataclass
 
 import numpy as np
@@ -6,8 +5,8 @@ import xarray as xr
 from sklearn.decomposition import NMF
 from xarray import Coordinates
 
+from cala.models.observable import Footprint, Footprints, Movie, Trace, Traces
 from cala.models.params import Parameters
-from cala.models.observable import Footprint, Footprints, Trace, Traces, Movie
 from cala.streaming.nodes import Node
 from cala.streaming.util.new import create_id
 

--- a/src/cala/streaming/nodes/init/cold/catalog.py
+++ b/src/cala/streaming/nodes/init/cold/catalog.py
@@ -6,7 +6,6 @@ import xarray as xr
 from sklearn.decomposition import NMF
 from xarray import Coordinates
 
-from cala.models.entity import Entities
 from cala.models.params import Parameters
 from cala.streaming.nodes import Node
 from cala.streaming.util.new import create_id
@@ -30,6 +29,7 @@ class Cataloger(Node):
         existing_tr: xr.DataArray = None,
         duplicates: list[tuple[str, float]] | None = None,
     ) -> tuple[xr.DataArray, xr.DataArray]:
+
         if not duplicates:
             footprints, traces = self._register(new_fp, new_tr, existing_fp, existing_tr)
 
@@ -56,8 +56,6 @@ class Cataloger(Node):
     def _init_with(
         self, new_fp: xr.DataArray, new_tr: xr.DataArray, confidence: float = 0.0
     ) -> tuple[xr.DataArray, xr.DataArray]:
-        new_fp.validate.against_schema(Entities.footprint.value)
-        new_tr.validate.against_schema(Entities.trace.value)
 
         new_id = create_id()
 

--- a/tests/test_streaming/unit/test_init/test_cold/test_cold_start.py
+++ b/tests/test_streaming/unit/test_init/test_cold/test_cold_start.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from cala.models.observable import Footprints, Traces, Footprint, Trace
+from cala.models.observable import Footprint, Footprints, Trace, Traces
 from cala.streaming.nodes.init.cold import (
     DupeSniffer,
     DupeSnifferParams,

--- a/tests/test_streaming/unit/test_init/test_cold/test_cold_start.py
+++ b/tests/test_streaming/unit/test_init/test_cold/test_cold_start.py
@@ -2,7 +2,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from cala.models.entity import Groups
 from cala.streaming.nodes.init.cold import (
     DupeSniffer,
     DupeSnifferParams,
@@ -72,8 +71,8 @@ class TestSliceNMF:
             SliceNMFParams(cell_radius=2 * simulator.cell_radii[0], validity_threshold=0.8)
         )
 
-    def test_get_max_energy_slice(self, slice_nmf, single_cell_video, energy):
-        slice_ = slice_nmf._get_max_energy_slice(single_cell_video, energy)
+    def test_get_max_energy_slice(self, slice_nmf, single_cell_video, energy_shape):
+        slice_ = slice_nmf._get_max_energy_slice(single_cell_video, energy_shape)
         return slice_
 
     def test_local_nmf(self, slice_nmf, single_cell_video, energy_shape, simulator):
@@ -139,6 +138,8 @@ class TestSniffer:
         ids = sniffer._find_overlap_ids(new_fp, simulator.footprints)
         assert np.all(ids == ["cell_0", "cell_1"])
 
+        simulator.drop_cell("cell_1")
+
     def test_get_overlapped_traces(self, simulator, new_component, sniffer):
         new_fp, _ = new_component
         ids = sniffer._find_overlap_ids(new_fp, simulator.footprints)
@@ -160,6 +161,8 @@ class TestSniffer:
         assert dupe[0][0] == "cell_0"
         assert np.isclose(dupe[0][1], 1.0)
 
+        simulator.drop_cell("cell_1")
+
 
 class TestCataloger:
     @pytest.fixture(scope="module")
@@ -179,17 +182,11 @@ class TestCataloger:
     def test_init_with(self, cataloger, new_component):
         fp, tr = cataloger._init_with(*new_component)
 
-        assert fp.validate.against_schema(Groups.footprint.value)
-        assert tr.validate.against_schema(Groups.trace.value)
-
         assert np.array_equal(fp.values[0], new_component[0].values)
         assert np.array_equal(tr.values[0], new_component[1].values)
 
     def test_register(self, cataloger, new_component, simulator):
         fp, tr = cataloger._register(*new_component, simulator.footprints, simulator.traces)
-
-        assert fp.validate.against_schema(Groups.footprint.value)
-        assert tr.validate.against_schema(Groups.trace.value)
 
         assert np.array_equal(fp.values[-1], new_component[0].values)
         assert np.array_equal(tr.values[-1], new_component[1].values)
@@ -201,9 +198,6 @@ class TestCataloger:
         fp, tr = cataloger._merge(
             *new_component, simulator.footprints, simulator.traces, duplicates=[("cell_0", 1.0)]
         )
-
-        assert fp.validate.against_schema(Groups.footprint.value)
-        assert tr.validate.against_schema(Groups.trace.value)
 
         movie_recon = fp @ tr
         new_fp, new_tr = new_component


### PR DESCRIPTION
## 📝 Description

Implementing essential array validation layer.

As the number of node operations and test fixtures grow, we're starting to encounter issues with inconsistent array schema and insufficient value checks. Some test fixtures maintain deprecated schemas, and corresponding nodes are still designed around the old schema (i.e. `type_` coordinates that has been deprecated but still exist in a lot of tests and codes).

This is causing redundant and obsolete tests, and most importantly, incompatibility between nodes by fundamentally breaking the object contracts between them.

To address this, we're in a desperate need of validation layer, where we make sure a `footprints` array truly is a `footprint`. This means it needs to have three dimensions: (height, width, component) and each dimension should have a certain set of coordinates, along with other relevant checks.

Since I'd like to enforce validation while providing type hints on what kinds of validations will be performed, the nodes must be formatted like the following:

```python
def node(fp: Footprints, tr: Traces, ...) -> Footprints: ...
```

I'm containing the DataArray as an attr. I've decided against directly inheriting from DataArray as it makes validating on assignment impossible, and against `Annotated` since it makes grabbing the annotation from outside the class difficult.

Thus,
```python
class Footprint(BaseModel):
    array: xr.DataArray
    model: DataArraySchema
```

usage:
```python
def node(fp: Footprints, tr: Traces, ...) -> Footprints:
    movie = fp.array @ tr.array
    # do things with movie
    fp.array = new_fp  # new_fp is new footprints
    return fp
```

This causes a few issues
1. I have to import `Footprints`, `Traces`, etc. every time I need to use them.
2. I have to access the DataArray with `.array` every time.
3. I'm wondering if I'm needlessly copying DataArrays.

Not sure if there's a better solution than this, however...


TODO: objects like `CompStats` have duplicate dims (component, component). Xarray does not like this, so the current solution is to attach a `'` on the name. This would be more difficult with a set schema.
1. One way to get around this is to not validate these objects.
4. The other is building a support for duplicate dimensions.


## 🔍 Type of Change

<!--
Please delete options that are not relevant.
-->
✨ **New Feature:** Introducing new functionality

## 🚀 Implementation Details


## 🧪 Testing

<!--
Describe the tests that you ran to verify your changes.
Provide instructions so that others can reproduce.
-->

- [x] Ran unit tests
- [x] Ran integration tests
- [x] Performed manual testing
- [x] Updated existing tests


## 🛠️ Dependencies

<!--
List any new dependencies added or existing ones updated.
-->


## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- readthedocs-preview cala start -->
----
📚 Documentation preview 📚: https://cala--113.org.readthedocs.build/en/113/

<!-- readthedocs-preview cala end -->